### PR TITLE
Verify working on .NET 7 Preview & all LTS versions

### DIFF
--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -10,10 +10,19 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest # So we can test against .NET Framework as well
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          # This should match the .NET versions in Moq.Contrib.HttpClient.Test.csproj
+          dotnet-version: |
+            3.1.x
+            6.0.x
+            7.0.x
+          include-prerelease: true
       - name: Test
         run: dotnet test -v normal
 

--- a/IntegrationTestExample/IntegrationTestExample.Test/IntegrationTestExample.Test.csproj
+++ b/IntegrationTestExample/IntegrationTestExample.Test/IntegrationTestExample.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/IntegrationTestExample/IntegrationTestExample.Web/IntegrationTestExample.Web.csproj
+++ b/IntegrationTestExample/IntegrationTestExample.Web/IntegrationTestExample.Web.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/Moq.Contrib.HttpClient.Test/Moq.Contrib.HttpClient.Test.csproj
+++ b/Moq.Contrib.HttpClient.Test/Moq.Contrib.HttpClient.Test.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!--
+      Run tests against the latest/preview version, every LTS version, and legacy .NET Framework.
+      The GitHub actions workflow should contain the same .NET versions.
+    -->
+    <TargetFrameworks>net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -16,6 +20,10 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
+++ b/Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
@@ -112,8 +112,8 @@ namespace Moq.Contrib.HttpClient.Test
             actual.Should().Be(expected);
 
             // Ensure this isn't simply matching any request
-            Func<Task> otherMethodAttempt = () => client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, url));
-            await otherMethodAttempt.Should().ThrowAsync<MockException>("the setup should not match a PATCH request");
+            Func<Task> otherMethodAttempt = () => client.SendAsync(new HttpRequestMessage(HttpMethod.Options, url));
+            await otherMethodAttempt.Should().ThrowAsync<MockException>("the setup should not match an OPTIONS request");
         }
 
         [Fact]
@@ -248,10 +248,6 @@ namespace Moq.Contrib.HttpClient.Test
             Action verifyThreeFoos = () => handler.VerifyRequest(fooUrl, Times.Exactly(3), "oh noes");
             Action verifyFooPosted = () => handler.VerifyRequest(HttpMethod.Post, fooUrl);
             Action verifyBarPosted = () => handler.VerifyRequest(HttpMethod.Post, barUrl, failMessage: "oh noes");
-            Action verifyFooPostedStuff = () => handler.VerifyRequest(HttpMethod.Post, fooUrl,
-                async r => (await r.Content.ReadAsStringAsync()) == "stuff");
-            Action verifyFooPostedOtherStuff = () => handler.VerifyRequest(HttpMethod.Post, fooUrl,
-                async r => (await r.Content.ReadAsStringAsync()) == "other stuff", failMessage: "oh noes");
 
             // Assert that these pass or fail accordingly
             verifyThreeRequests.Should().NotThrow("we made three requests");
@@ -260,11 +256,9 @@ namespace Moq.Contrib.HttpClient.Test
             verifyThreeFoos.Should().Throw<MockException>("there were two requests to foo, not three");
             verifyFooPosted.Should().NotThrow("we sent a POST to foo");
             verifyBarPosted.Should().Throw<MockException>("we did not send a POST to bar");
-            verifyFooPostedStuff.Should().NotThrow("we sent the string \"stuff\"");
-            verifyFooPostedOtherStuff.Should().Throw<MockException>("we sent the string \"stuff\", not \"other stuff\"");
 
             // The fail messages should be passed along as well
-            var messages = new[] { verifyMoreThanThreeRequests, verifyThreeFoos, verifyBarPosted, verifyFooPostedOtherStuff }
+            var messages = new[] { verifyMoreThanThreeRequests, verifyThreeFoos, verifyBarPosted }
                 .Select(f => { try { f(); return null; } catch (MockException ex) { return ex.Message; } });
             messages.Should().OnlyContain(x => x.Contains("oh noes"), "all verify exceptions should contain the failMessage");
         }

--- a/Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs
+++ b/Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs
@@ -107,29 +107,30 @@ namespace Moq.Contrib.HttpClient.Test
         [InlineData(HttpStatusCode.BadRequest, new byte[] { }, null)]
         public async Task RespondsWithStream(HttpStatusCode? statusCode, byte[] bytes, string mediaType)
         {
-            using MemoryStream stream = new MemoryStream(bytes);
-
-            if (statusCode.HasValue)
+            using (MemoryStream stream = new MemoryStream(bytes))
             {
-                handler.SetupAnyRequest()
-                    .ReturnsResponse(statusCode.Value, stream, mediaType);
+                if (statusCode.HasValue)
+                {
+                    handler.SetupAnyRequest()
+                        .ReturnsResponse(statusCode.Value, stream, mediaType);
+                }
+                else
+                {
+                    // Status code can be omitted and defaults to OK
+                    handler.SetupAnyRequest()
+                        .ReturnsResponse(stream, mediaType);
+                }
+
+                var response = await client.GetAsync("");
+                var responseBytes = await response.Content.ReadAsByteArrayAsync();
+
+                response.Content.Should().BeOfType<StreamContent>();
+                response.StatusCode.Should().Be(statusCode ?? HttpStatusCode.OK);
+                responseBytes.Should().BeEquivalentTo(bytes);
+
+                var responseMediaType = response.Content.Headers.ContentType?.MediaType;
+                responseMediaType.Should().Be(mediaType);
             }
-            else
-            {
-                // Status code can be omitted and defaults to OK
-                handler.SetupAnyRequest()
-                    .ReturnsResponse(stream, mediaType);
-            }
-
-            var response = await client.GetAsync("");
-            var responseBytes = await response.Content.ReadAsByteArrayAsync();
-
-            response.Content.Should().BeOfType<StreamContent>();
-            response.StatusCode.Should().Be(statusCode ?? HttpStatusCode.OK);
-            responseBytes.Should().BeEquivalentTo(bytes);
-
-            var responseMediaType = response.Content.Headers.ContentType?.MediaType;
-            responseMediaType.Should().Be(mediaType);
         }
 
         [Fact]
@@ -232,39 +233,40 @@ namespace Moq.Contrib.HttpClient.Test
             int offsetStreamPosition = 39;
             byte[] expectedOffsetBytes = bytes.Skip(offsetStreamPosition).ToArray();
 
-            using MemoryStream stream = new MemoryStream(bytes);
-            using MemoryStream offsetStream = new MemoryStream(bytes);
+            using (MemoryStream stream = new MemoryStream(bytes))
+            using (MemoryStream offsetStream = new MemoryStream(bytes))
+            {
+                handler.SetupRequest(HttpMethod.Get, "https://example.com/normal")
+                    .ReturnsResponse(stream);
 
-            handler.SetupRequest(HttpMethod.Get, "https://example.com/normal")
-                .ReturnsResponse(stream);
+                // Multiple setups can share the same stream as well
+                handler.SetupRequest(HttpMethod.Get, "https://example.com/normal2")
+                    .ReturnsResponse(stream);
 
-            // Multiple setups can share the same stream as well
-            handler.SetupRequest(HttpMethod.Get, "https://example.com/normal2")
-                .ReturnsResponse(stream);
+                // This stream is the same but seeked forward; each request should read from this position rather than
+                // seeking back to the beginning
+                offsetStream.Seek(offsetStreamPosition, SeekOrigin.Begin);
+                handler.SetupRequest(HttpMethod.Get, "https://example.com/offset")
+                    .ReturnsResponse(offsetStream);
 
-            // This stream is the same but seeked forward; each request should read from this position rather than
-            // seeking back to the beginning
-            offsetStream.Seek(offsetStreamPosition, SeekOrigin.Begin);
-            handler.SetupRequest(HttpMethod.Get, "https://example.com/offset")
-                .ReturnsResponse(offsetStream);
+                var responseBytes1 = await client.GetByteArrayAsync("normal");
+                var responseBytes2 = await client.GetByteArrayAsync("normal");
+                var responseBytes3 = await client.GetByteArrayAsync("normal2");
 
-            var responseBytes1 = await client.GetByteArrayAsync("normal");
-            var responseBytes2 = await client.GetByteArrayAsync("normal");
-            var responseBytes3 = await client.GetByteArrayAsync("normal2");
+                var offsetResponseBytes1 = await client.GetByteArrayAsync("offset");
+                var offsetResponseBytes2 = await client.GetByteArrayAsync("offset");
 
-            var offsetResponseBytes1 = await client.GetByteArrayAsync("offset");
-            var offsetResponseBytes2 = await client.GetByteArrayAsync("offset");
+                responseBytes1.Should().BeEquivalentTo(bytes);
+                responseBytes2.Should().BeEquivalentTo(bytes,
+                    "the stream should be returned to its original position after being read");
+                responseBytes3.Should().BeEquivalentTo(bytes,
+                    "the stream should be reusable not just between requests to one setup but also between setups");
 
-            responseBytes1.Should().BeEquivalentTo(bytes);
-            responseBytes2.Should().BeEquivalentTo(bytes,
-                "the stream should be returned to its original position after being read");
-            responseBytes3.Should().BeEquivalentTo(bytes,
-                "the stream should be reusable not just between requests to one setup but also between setups");
-
-            offsetResponseBytes1.Should().BeEquivalentTo(expectedOffsetBytes,
-                "the stream should read from its initial (offset) position, not necessarily the beginning");
-            offsetResponseBytes2.Should().BeEquivalentTo(expectedOffsetBytes,
-                "the stream should be returned to its original (offset, not zero) position after being read");
+                offsetResponseBytes1.Should().BeEquivalentTo(expectedOffsetBytes,
+                    "the stream should read from its initial (offset) position, not necessarily the beginning");
+                offsetResponseBytes2.Should().BeEquivalentTo(expectedOffsetBytes,
+                    "the stream should be returned to its original (offset, not zero) position after being read");
+            }
         }
     }
 }

--- a/Moq.Contrib.HttpClient/ResponseExtensions.cs
+++ b/Moq.Contrib.HttpClient/ResponseExtensions.cs
@@ -153,7 +153,7 @@ namespace Moq.Contrib.HttpClient
                 return CreateResponse(
                     request: request,
                     statusCode: statusCode,
-                    content: new StringContent(content, encoding, mediaType),
+                    content: new StringContent(content, encoding, mediaType ?? "text/plain"),
                     configure: configure);
             });
         }
@@ -183,7 +183,7 @@ namespace Moq.Contrib.HttpClient
 
             return setup.ReturnsAsync(CreateResponse(
                 statusCode: statusCode,
-                content: new StringContent(content, encoding, mediaType),
+                content: new StringContent(content, encoding, mediaType ?? "text/plain"),
                 configure: configure));
         }
 
@@ -212,7 +212,7 @@ namespace Moq.Contrib.HttpClient
             {
                 return CreateResponse(
                     request: request,
-                    content: new StringContent(content, encoding, mediaType),
+                    content: new StringContent(content, encoding, mediaType ?? "text/plain"),
                     configure: configure);
             });
         }
@@ -240,7 +240,7 @@ namespace Moq.Contrib.HttpClient
             }
 
             return setup.ReturnsAsync(CreateResponse(
-                content: new StringContent(content, encoding, mediaType),
+                content: new StringContent(content, encoding, mediaType ?? "text/plain"),
                 configure: configure));
         }
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 # Moq.Contrib.HttpClient
 
-[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build]
+[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build] ![tested on badge]
 
 [English](README.md)
 
@@ -226,9 +226,10 @@ public class ExampleTests : IClassFixture<WebApplicationFactory<Startup>>
 MIT
 
 [nuget]: https://www.nuget.org/packages/Moq.Contrib.HttpClient/
-[nuget badge]: https://img.shields.io/nuget/dt/Moq.Contrib.HttpClient?label=Downloads&logo=nuget&logoColor=959da5&labelColor=2d343a
+[nuget badge]: https://img.shields.io/nuget/dt/Moq.Contrib.HttpClient?label=Downloads&logo=nuget&logoColor=959da5&labelColor=2d343a&color=2dbb4e
 [ci build]: https://github.com/maxkagamine/Moq.Contrib.HttpClient/actions?query=workflow%3A%22CI+build%22
 [ci build badge]: https://github.com/maxkagamine/Moq.Contrib.HttpClient/workflows/CI%20build/badge.svg?branch=master&event=push
+[tested on badge]: https://img.shields.io/badge/dynamic/xml?label=tested%20on&query=translate%28%2F%2FPropertyGroup%2FTargetFrameworks%2C%22%3B%22%2C%22%EF%BD%9C%22%29&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmaxkagamine%2FMoq.Contrib.HttpClient%2Fmaster%2FMoq.Contrib.HttpClient.Test%2FMoq.Contrib.HttpClient.Test.csproj&color=555&labelColor=2d343a
 
 [RequestExtensionsTests]: Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
 [ResponseExtensionsTests]: Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Moq.Contrib.HttpClient
 
-[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build]
+[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build] ![tested on badge]
 
 [日本語](README.ja.md)
 
@@ -270,9 +270,10 @@ various helpers and different use cases:
 MIT
 
 [nuget]: https://www.nuget.org/packages/Moq.Contrib.HttpClient/
-[nuget badge]: https://img.shields.io/nuget/dt/Moq.Contrib.HttpClient?label=Downloads&logo=nuget&logoColor=959da5&labelColor=2d343a
+[nuget badge]: https://img.shields.io/nuget/dt/Moq.Contrib.HttpClient?label=Downloads&logo=nuget&logoColor=959da5&labelColor=2d343a&color=2dbb4e
 [ci build]: https://github.com/maxkagamine/Moq.Contrib.HttpClient/actions?query=workflow%3A%22CI+build%22
 [ci build badge]: https://github.com/maxkagamine/Moq.Contrib.HttpClient/workflows/CI%20build/badge.svg?branch=master&event=push
+[tested on badge]: https://img.shields.io/badge/dynamic/xml?label=tested%20on&query=translate%28%2F%2FPropertyGroup%2FTargetFrameworks%2C%22%3B%22%2C%22%EF%BD%9C%22%29&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmaxkagamine%2FMoq.Contrib.HttpClient%2Fmaster%2FMoq.Contrib.HttpClient.Test%2FMoq.Contrib.HttpClient.Test.csproj&color=555&labelColor=2d343a
 
 [RequestExtensionsTests]: Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
 [ResponseExtensionsTests]: Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs


### PR DESCRIPTION
The latest .NET 7 preview introduces a breaking change to the StringContent constructor where it no longer accepts null for `mediaType` (dotnet/runtime#63231). ReturnsResponse has been updated to default to text/plain (which is still StringContent's default when the `mediaType` parameter is not used). Fixes #9.

To better catch these sorts of problems in the future, the unit tests will now run against **the latest/preview .NET version, every LTS version, and legacy .NET Framework**. Unfortunately this still needs to be updated manually. Currently the frameworks that are tested are:

- .NET 7.0 Preview
- .NET 6.0 _(end of life Nov 2024)_
- .NET Core 3.1 _(end of life Dec 2022)_
- .NET Framework 4.8