### PR TITLE
Recommend using MockBehavior.Strict for HttpClient

### DIFF
--- a/Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
+++ b/Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace Moq.Contrib.HttpClient.Test
         [Fact]
         public async Task MatchesAnyRequest()
         {
-            var handler = new Mock<HttpMessageHandler>();
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             var client = handler.CreateClient(); // Equivalent to `new HttpClient(handler.Object, false)`
 
             // See ResponseExtensionsTests for response examples; this could be shortened to `.ReturnsResponse("foo")`
@@ -37,8 +37,8 @@ namespace Moq.Contrib.HttpClient.Test
             (await client.PostAsync("https://example.com/foo", new StringContent("data"))).Should().BeSameAs(response);
             (await client.GetStringAsync("https://example.com/bar")).Should().Be("foo");
 
-            // Verify methods are provided matching the setup helpers, although HttpClient will throw if the request was
-            // not mocked, so in many cases a Verify will be redundant
+            // Verify methods are provided matching the setup helpers, although even without MockBehavior.Strict,
+            // HttpClient will throw if the request was not mocked, so in many cases a Verify will be redundant
             handler.VerifyAnyRequest(Times.Exactly(3));
         }
 
@@ -84,9 +84,6 @@ namespace Moq.Contrib.HttpClient.Test
             // The handler was created with MockBehavior.Strict which throws a MockException for invocations without setups
             Func<Task> esAttempt = () => GetGreeting("es-ES", "mundo");
             await esAttempt.Should().ThrowAsync<MockException>(because: "a setup for Spanish was not configured");
-
-            handler.VerifyRequest(enUrl, Times.Once());
-            handler.VerifyRequest(jaUrl, Times.Once());
         }
 
         [Theory]
@@ -119,7 +116,7 @@ namespace Moq.Contrib.HttpClient.Test
         [Fact]
         public async Task MatchesCustomPredicate()
         {
-            var handler = new Mock<HttpMessageHandler>();
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             var client = handler.CreateClient();
 
             // Let's simulate posting a song to a music API
@@ -178,8 +175,7 @@ namespace Moq.Contrib.HttpClient.Test
                 Url = "https://vocadb.net/S/21567"
             }, token);
 
-            // Loose mode, so HttpClient receives null and throws InvalidOperationException
-            await wrongSongAttempt.Should().ThrowAsync<InvalidOperationException>("wrong request body");
+            await wrongSongAttempt.Should().ThrowAsync<MockException>("wrong request body");
 
             // Attempt to create the song again, this time without a valid token (if we were actually testing a service,
             // this would probably be a separate unit test)
@@ -190,7 +186,7 @@ namespace Moq.Contrib.HttpClient.Test
         [Fact]
         public async Task MatchesQueryParameters()
         {
-            var handler = new Mock<HttpMessageHandler>();
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             var client = handler.CreateClient();
 
             string baseUrl = "https://example.com:8080/api/v2";
@@ -223,7 +219,7 @@ namespace Moq.Contrib.HttpClient.Test
         [Fact]
         public async Task VerifyHelpersThrowAsExpected() // This one is mainly for code coverage
         {
-            var handler = new Mock<HttpMessageHandler>();
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             var client = handler.CreateClient();
 
             // Mock two different endpoints

--- a/Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs
+++ b/Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Moq.Contrib.HttpClient.Test
 
         public ResponseExtensionsTests()
         {
-            handler = new Mock<HttpMessageHandler>();
+            handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             client = handler.CreateClient();
 
             // Setting a BaseAddress only affects HttpClient's methods; the handler doesn't know about the BaseAddress
@@ -175,9 +175,6 @@ namespace Moq.Contrib.HttpClient.Test
         [Fact]
         public async Task CanSimulateNetworkErrors()
         {
-            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-            var client = handler.CreateClient();
-
             // Triggering a network error (e.g. connection refused) can be done using the standard Throws()
             handler.SetupAnyRequest()
                 .Throws<HttpRequestException>();

--- a/README.ja.md
+++ b/README.ja.md
@@ -73,7 +73,7 @@ ReturnsResponse([HttpStatusCode statusCode, ]byte[]|Stream content, string media
 
 ```csharp
 // HttpClientで送ったリクエストがモックされるハンドラのSendAsync()中に通る
-var handler = new Mock<HttpMessageHandler>();
+var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 var client = handler.CreateClient();
 
 // すべてのリクエストに404を送る簡単な例え
@@ -91,6 +91,49 @@ handler.SetupRequest(HttpMethod.Get, "https://example.com/api/stuff")
         response.Content.Headers.LastModified = new DateTime(2022, 3, 9);
     });
 ```
+
+<blockquote>
+<details>
+<summary>💡 なぜHttpClientのためにMockBehavior.Strictを使うべき</summary>
+<br />
+
+以下の点を考慮します：
+
+```csharp
+handler.SetupRequest(HttpMethod.Get, "https://example.com/api/foos")
+    .ReturnsJsonResponse(expected);
+
+List<Foo> actual = await foosService.GetFoos();
+
+actual.Should().BeEquivalentTo(expected);
+```
+
+このテストは以下の例外で予期せず失敗する：
+
+```
+System.InvalidOperationException : Handler did not return a response message.
+```
+
+なぜならMoqはセットアップがマッチしない場合既定値を返すLooseモードがデフォルトですが、HttpClientはハンドラからnullを受け取るとInvalidOperationExceptionをスローする
+
+MockBehavior.Strictに変更したら：
+
+```diff
+- var handler = new Mock<HttpMessageHandler>();
++ var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+```
+
+もっと便利な例外をもらって、送ったリクエストも付いてる (ここ、URLがfoosではなくfooとミスされた)：
+
+```
+Moq.MockException : HttpMessageHandler.SendAsync(Method: GET, RequestUri: 'https://example.com/api/foo', Version: 1.1, Content: <null>, Headers:
+{
+}, System.Threading.CancellationToken) invocation failed with mock behavior Strict.
+All invocations on the mock must have a corresponding setup.
+```
+
+</details>
+</blockquote>
 
 ### クエリパラメータやヘッダーやJSONボディでリクエストをマッチする
 


### PR DESCRIPTION
Consider the following:

```csharp
handler.SetupRequest(HttpMethod.Get, "https://example.com/api/foos")
    .ReturnsJsonResponse(expected);

List<Foo> actual = await foosService.GetFoos();

actual.Should().BeEquivalentTo(expected);
```

This test fails unexpectedly with the following exception:

```
System.InvalidOperationException : Handler did not return a response message.
```

This is because Moq defaults to Loose mode which returns a default value if no setup matches, but HttpClient throws an InvalidOperationException if it receives null from the handler.

If we change it to MockBehavior.Strict:

```diff
- var handler = new Mock<HttpMessageHandler>();
+ var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
```

We get a more useful exception that also includes the request that was made (here we see the URL was typo'd as "foo" instead of "foos"):

```
Moq.MockException : HttpMessageHandler.SendAsync(Method: GET, RequestUri: 'https://example.com/api/foo', Version: 1.1, Content: <null>, Headers:
{
}, System.Threading.CancellationToken) invocation failed with mock behavior Strict.
All invocations on the mock must have a corresponding setup.
```