### PR TITLE
System.Text.Json support via new ReturnsJsonResponse methods

### DIFF
--- a/Moq.Contrib.HttpClient.Test/Models.cs
+++ b/Moq.Contrib.HttpClient.Test/Models.cs
@@ -1,0 +1,16 @@
+﻿namespace Moq.Contrib.HttpClient.Test
+{
+    /// <summary>
+    /// Model used by a fictitious music API in a couple examples.
+    /// </summary>
+    public class Song
+    {
+        public string Title { get; set; }
+
+        public string Artist { get; set; }
+
+        public string Album { get; set; }
+
+        public string Url { get; set; }
+    }
+}

--- a/Moq.Contrib.HttpClient.Test/Moq.Contrib.HttpClient.Test.csproj
+++ b/Moq.Contrib.HttpClient.Test/Moq.Contrib.HttpClient.Test.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Flurl" Version="2.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Polly" Version="6.1.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Moq.Contrib.HttpClient/Moq.Contrib.HttpClient.csproj
+++ b/Moq.Contrib.HttpClient/Moq.Contrib.HttpClient.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Moq" Version="[4.8.0,5)" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Moq.Contrib.HttpClient/RequestMatcher.cs
+++ b/Moq.Contrib.HttpClient/RequestMatcher.cs
@@ -23,10 +23,14 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(Predicate<HttpRequestMessage> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
 
-            return Match.Create(match, () => Is(match));
+            var requestPredicate = new RequestPredicate(match);
+
+            return Match.Create(requestPredicate.Matches, () => Is(match));
         }
 
         /// <summary>
@@ -36,10 +40,14 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(Func<HttpRequestMessage, Task<bool>> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
 
-            return Match.Create(r => match(r).Result, () => Is(match)); // Blocking
+            var requestPredicate = new RequestPredicate(match);
+
+            return Match.Create(requestPredicate.Matches, () => Is(match)); // Blocking
         }
 
         /// <summary>
@@ -64,11 +72,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(Uri requestUri, Predicate<HttpRequestMessage> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.RequestUri == requestUri && match(r),
+                r => r.RequestUri == requestUri && requestPredicate.Matches(r),
                 () => Is(requestUri, match));
         }
 
@@ -80,11 +92,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(Uri requestUri, Func<HttpRequestMessage, Task<bool>> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.RequestUri == requestUri && match(r).Result, // Blocking
+                r => r.RequestUri == requestUri && requestPredicate.Matches(r), // Blocking
                 () => Is(requestUri, match));
         }
 
@@ -114,11 +130,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(HttpMethod method, Predicate<HttpRequestMessage> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.Method == method && match(r),
+                r => r.Method == method && requestPredicate.Matches(r),
                 () => Is(method, match));
         }
 
@@ -130,11 +150,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(HttpMethod method, Func<HttpRequestMessage, Task<bool>> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.Method == method && match(r).Result, // Blocking
+                r => r.Method == method && requestPredicate.Matches(r), // Blocking
                 () => Is(method, match));
         }
 
@@ -165,11 +189,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(HttpMethod method, Uri requestUri, Predicate<HttpRequestMessage> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.Method == method && r.RequestUri == requestUri && match(r),
+                r => r.Method == method && r.RequestUri == requestUri && requestPredicate.Matches(r),
                 () => Is(method, requestUri, match));
         }
 
@@ -182,11 +210,15 @@ namespace Moq.Contrib.HttpClient
         /// <exception cref="ArgumentNullException"><paramref name="match" /> is null.</exception>
         public static HttpRequestMessage Is(HttpMethod method, Uri requestUri, Func<HttpRequestMessage, Task<bool>> match)
         {
-            if (match == null)
+            if (match is null)
+            {
                 throw new ArgumentNullException(nameof(match));
+            }
+
+            var requestPredicate = new RequestPredicate(match);
 
             return Match.Create(
-                r => r.Method == method && r.RequestUri == requestUri && match(r).Result, // Blocking
+                r => r.Method == method && r.RequestUri == requestUri && requestPredicate.Matches(r), // Blocking
                 () => Is(method, requestUri, match));
         }
 

--- a/Moq.Contrib.HttpClient/RequestPredicate.cs
+++ b/Moq.Contrib.HttpClient/RequestPredicate.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Moq.Contrib.HttpClient
+{
+    /// <summary>
+    /// Memoizes the result of a `match` predicate for a given request to prevent the predicate from being called
+    /// repeatedly, which may cause it to throw if the request content had been consumed and its stream closed.
+    /// </summary>
+    internal class RequestPredicate
+    {
+        private readonly Func<HttpRequestMessage, Task<bool>> match;
+        private readonly ConditionalWeakTable<HttpRequestMessage, Task<bool>> memoizedResults = new ConditionalWeakTable<HttpRequestMessage, Task<bool>>();
+
+        public RequestPredicate(Func<HttpRequestMessage, Task<bool>> match)
+        {
+            this.match = match ?? throw new ArgumentNullException(nameof(match));
+        }
+
+        public RequestPredicate(Predicate<HttpRequestMessage> match)
+            : this(r => Task.FromResult(match(r)))
+        { }
+
+        public Task<bool> MatchesAsync(HttpRequestMessage request)
+        {
+            if (!memoizedResults.TryGetValue(request, out var result))
+            {
+                result = match(request);
+                memoizedResults.Add(request, result);
+            }
+
+            return result;
+        }
+
+        public bool Matches(HttpRequestMessage request) => MatchesAsync(request).Result;
+    }
+}

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 MoqでHttpClientとIHttpClientFactoryのテストダブルを作るための拡張メソッドです
 
-かつて、HttpClientをモックすることが[驚くほど難しかって][dotnet/runtime#14535]、解決方法はHttpClientそのものをモックする代わりにラッパーを作ること、あるいは他のHTTPライブラリで完全に置き換えることでした。このパッケージはHTTPリクエストのモックをサービスメソッドと同じように簡単にする拡張メソッドを提供する
+かつて、HttpClientをモックすることが[驚くほど難しかって][dotnet/runtime#14535]、解決方法はHttpClientそのものをモックする代わりにラッパーを作ること、あるいは他のHTTPライブラリで完全に置き換えることでした。このパッケージはHTTPリクエストのモックをサービスメソッドと同じように簡単にする拡張メソッドを[Moq]に付加する
 
 - [インストール](#インストール)
 - [API](#api)
@@ -148,9 +148,8 @@ handler
     .SetupRequest(HttpMethod.Post, url, async request =>
     {
         // このセットアップは予期されるIDのあるリクエストのみをマッチする
-        var json = await request.Content.ReadAsStringAsync();
-        var model = JsonSerializer.Deserialize<Model>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
-        return model.Id == expected.Id;
+        var json = await request.Content.ReadFromJsonAsync<Model>();
+        return json.Id == expected.Id;
     })
     .ReturnsResponse(HttpStatusCode.Created);
 
@@ -289,7 +288,8 @@ MIT
 [integration tests]: https://docs.microsoft.com/ja-jp/aspnet/core/test/integration-tests
 [System.Text.Json]: https://docs.microsoft.com/ja-jp/dotnet/standard/serialization/system-text-json-how-to
 
-[AutoMocker]: https://github.com/moq/Moq.AutoMocker
+[Moq]: https://github.com/moq/moq4#readme
+[AutoMocker]: https://github.com/moq/Moq.AutoMocker#readme
 [dotnet/runtime#14535]: https://github.com/dotnet/corefx/issues/1624
 [Flurl]: https://flurl.io/docs/fluent-url/
 [httpclientwrong]: https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 # Moq.Contrib.HttpClient
 
-[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build] ![tested on badge]
+[![NuGet][nuget badge]][nuget] [![ci build badge]][ci build] [![tested on badge]](#)
 
 [English](README.md)
 
@@ -40,7 +40,7 @@ Moqの普通のメソッドにリクエスト版とレスポンス版が追加�
 - **Setup** → SetupRequest, SetupAnyRequest
 - **SetupSequence** → SetupRequestSequence, SetupAnyRequestSequence
 - **Verify** → VerifyRequest, VerifyAnyRequest
-- **Returns(Async)** → ReturnsResponse
+- **Returns(Async)** → ReturnsResponse, ReturnsJsonResponse
 
 ### リクエスト
 
@@ -57,12 +57,13 @@ SetupRequest(HttpMethod method, string|Uri requestUrl[, Predicate<HttpRequestMes
 
 ### レスポンス
 
-レスポンスのヘルパーはStringContent、ByteArrayContent、StreamContent、それともステータスコードだけを送ることを簡単にする：
+レスポンスのヘルパーはStringContent、JsonContent（[System.Text.Json]による）、ByteArrayContent、StreamContent、それともステータスコードだけを送ることを簡単にする：
 
 ```csharp
 ReturnsResponse(HttpStatusCode statusCode[, HttpContent content], Action<HttpResponseMessage> configure = null)
 ReturnsResponse([HttpStatusCode statusCode, ]string content, string mediaType = null, Encoding encoding = null, Action<HttpResponseMessage> configure = null))
 ReturnsResponse([HttpStatusCode statusCode, ]byte[]|Stream content, string mediaType = null, Action<HttpResponseMessage> configure = null)
+ReturnsJsonResponse<T>([HttpStatusCode statusCode, ]T value, JsonSerializerOptions options = null, Action<HttpResponseMessage> configure = null)
 ```
 
 `statusCode`が省略されると200 OKにディフォルトする。`configure`アクションがレスポンスのヘッダーを設定するように使える
@@ -82,7 +83,7 @@ handler.SetupAnyRequest()
 
 // JSONを返すエンドポイントへのGETリクエストをマッチする (200 OKにデフォルトする)
 handler.SetupRequest(HttpMethod.Get, "https://example.com/api/stuff")
-    .ReturnsResponse(JsonConvert.SerializeObject(model), "application/json");
+    .ReturnsJsonResponse(model);
 
 // 任意なconfigureアクションでレスポンスにもっとのヘッダーを設定する
 handler.SetupRequest(HttpMethod.Get, "https://example.com/api/stuff")
@@ -148,7 +149,7 @@ handler
     {
         // このセットアップは予期されるIDのあるリクエストのみをマッチする
         var json = await request.Content.ReadAsStringAsync();
-        var model = JsonConvert.DeserializeObject<Model>();
+        var model = JsonSerializer.Deserialize<Model>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
         return model.Id == expected.Id;
     })
     .ReturnsResponse(HttpStatusCode.Created);
@@ -164,7 +165,9 @@ handler
     .ReturnsResponse("stuff");
 ```
 
-最後のはクエリ文字列のチェックに役立つ[Flurl]というURLビルダーのライブラリを使う。これ以上の説明は[リクエスト拡張のテスト][RequestExtensionsTests]のMatchesCustomPredicateとMatchesQueryParametersを見てください
+最後のはクエリ文字列のチェックに役立つ[Flurl]というURLビルダーのライブラリを使う
+
+JSONリクエストのいろいろな確認方法など、詳しい説明は[リクエスト拡張のテスト][RequestExtensionsTests]のMatchesCustomPredicateとMatchesQueryParametersを見てください
 
 ### リクエストのシークエンスをセットアップする
 
@@ -260,8 +263,8 @@ public class ExampleTests : IClassFixture<WebApplicationFactory<Startup>>
 
 このライブラリのユニットテストがヘルパーやさまざまなユースケースの例として役立つように書かれた：
 
-- **[リクエスト拡張のテスト][RequestExtensionsTests]** &mdash; SetupとVerifyのヘルパーに焦点をあてる
-- **[レスポンス拡張のテスト][ResponseExtensionsTests]** &mdash; ReturnsResponseのオーバーロードに焦点をあてます
+- **[リクエスト拡張のテスト][RequestExtensionsTests]** &mdash; SetupとVerifyのヘルパーに焦点をあてて、リクエストをマッチするいろいろな方法を説明する
+- **[レスポンス拡張のテスト][ResponseExtensionsTests]** &mdash; ReturnsResponse（とReturnsJsonResponse）のオーバーロードに焦点をあてます
 - **[シークエンス拡張のテスト][SequenceExtensionsTests]** &mdash; 明示的なシークエンスをモックすることを実証する
 
 ## ライセンス
@@ -284,6 +287,7 @@ MIT
 [middleware]: https://docs.microsoft.com/ja-jp/aspnet/core/fundamentals/http-requests#outgoing-request-middleware
 [named clients]: https://docs.microsoft.com/ja-jp/aspnet/core/fundamentals/http-requests#named-clients
 [integration tests]: https://docs.microsoft.com/ja-jp/aspnet/core/test/integration-tests
+[System.Text.Json]: https://docs.microsoft.com/ja-jp/dotnet/standard/serialization/system-text-json-how-to
 
 [AutoMocker]: https://github.com/moq/Moq.AutoMocker
 [dotnet/runtime#14535]: https://github.com/dotnet/corefx/issues/1624

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Moq.
 Mocking HttpClient has historically been [surprisingly
 difficult][dotnet/runtime#14535], with the solution being to either create a
 wrapper to mock instead (at the cost of cluttering the code) or use a separate
-HTTP library entirely. This package provides extension methods that make mocking
-HTTP requests as easy as mocking a service method.
+HTTP library entirely. This package provides extension methods for [Moq] that
+make handling HTTP requests as easy as mocking a service method.
 
 - [Install](#install)
 - [API](#api)
@@ -160,9 +160,8 @@ handler
     .SetupRequest(HttpMethod.Post, url, async request =>
     {
         // This setup will only match calls with the expected id
-        var json = await request.Content.ReadAsStringAsync();
-        var model = JsonSerializer.Deserialize<Model>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
-        return model.Id == expected.Id;
+        var json = await request.Content.ReadFromJsonAsync<Model>();
+        return json.Id == expected.Id;
     })
     .ReturnsResponse(HttpStatusCode.Created);
 
@@ -337,7 +336,8 @@ MIT
 [integration tests]: https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests
 [System.Text.Json]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to
 
-[AutoMocker]: https://github.com/moq/Moq.AutoMocker
+[Moq]: https://github.com/moq/moq4#readme
+[AutoMocker]: https://github.com/moq/Moq.AutoMocker#readme
 [dotnet/runtime#14535]: https://github.com/dotnet/corefx/issues/1624
 [Flurl]: https://flurl.io/docs/fluent-url/
 [httpclientwrong]: https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/


### PR DESCRIPTION
Long-overdue [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to) extensions!

The new **ReturnsJsonResponse** methods (named so due to being otherwise ambiguous) are functionally similar to the [System.Net.Http.Json extensions](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.json.httpclientjsonextensions), PostAsJsonAsync<T>() etc., and send a [JsonContent](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.json.jsoncontent) instead of StringContent.

Example usage (see [ResponseExtensionsTests](https://github.com/maxkagamine/Moq.Contrib.HttpClient/blob/master/Moq.Contrib.HttpClient.Test/ResponseExtensionsTests.cs)):

```csharp
List<Song> expected = /* ... */;

handler.SetupRequest(HttpMethod.Get, "https://example.com/api/songs")
    .ReturnsJsonResponse(expected);

var actual = await client.GetFromJsonAsync<List<Song>>("api/songs");

actual.Should().BeEquivalentTo(expected);
```

[RequestExtensionsTests](https://github.com/maxkagamine/Moq.Contrib.HttpClient/blob/master/Moq.Contrib.HttpClient.Test/RequestExtensionsTests.cs) has also been updated with examples of using System.Text.Json to match requests:

```csharp
handler
    .SetupRequest(HttpMethod.Post, url, async request =>
    {
        var json = await request.Content.ReadFromJsonAsync<Model>();
        return json.Id == expected.Id;
    })
    .ReturnsResponse(HttpStatusCode.Created);
```

Or if you know the code under test is using the System.Text.Json extensions:

```csharp
handler
    .SetupRequest(HttpMethod.Post, url, r => ((JsonContent)r.Content).Value == model)
    .ReturnsResponse(HttpStatusCode.Created);
```

This pairs especially well with [record types](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/records).